### PR TITLE
fix: アプリのタイトルを「はんなりプロンプトキッチン」に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <title>多機能プロンプト生成アプリ プロトタイプ</title>
+    <title>はんなりプロンプトキッチン</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
@@ -11,7 +11,7 @@
 <body>
     <div class="container">
         <header class="text-center py-8">
-            <h1 class="text-3xl font-bold text-gray-800">多機能プロンプト生成アプリ <span class="text-blue-600">(プロトタイプ)</span></h1>
+            <h1 class="text-3xl font-bold text-gray-800">はんなりプロンプトキッチン</h1>
             <p class="text-gray-600 mt-2">目的に合わせたプロンプトを簡単に生成します。</p>
         </header>
 


### PR DESCRIPTION
## Summary
- アプリのタイトルを「多機能プロンプト生成アプリ (プロトタイプ)」から「はんなりプロンプトキッチン」に変更しました
- `<title>`タグとヘッダーの`<h1>`タグの両方を更新しました

## Related Issue
Fixes #2

## Test plan
- [x] ブラウザでindex.htmlを開く
- [x] ブラウザのタブに「はんなりプロンプトキッチン」と表示されることを確認
- [x] ページヘッダーに「はんなりプロンプトキッチン」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)