### PR TITLE
fix: プロンプト表示ボックスの文字配置を修正

### DIFF
--- a/style.css
+++ b/style.css
@@ -260,6 +260,9 @@ button {
     font-size: 0.9em;
     line-height: 1.6;
     overflow-x: auto; /* Horizontal scroll for long lines */
+    text-align: left; /* Ensure text is aligned to the left */
+    vertical-align: top; /* Align content to top */
+    display: block; /* Ensure block display */
 }
 
 /* Mobile prompt output styling */


### PR DESCRIPTION
## Summary
- プロンプト表示ボックスの「ここにプロンプトが表示されます...」という文字が左上端に正しく表示されるように修正しました

## Changes
- `.prompt-output` クラスに `text-align: left` を追加
- `vertical-align: top` を追加して上端配置を保証
- `display: block` を明示的に指定

## Related Issue
Fixes #7

## Test plan
- [ ] ブラウザでindex.htmlを開く
- [ ] プロンプト表示ボックスの初期表示文字が左上端に表示されることを確認
- [ ] タブを切り替えても文字配置が崩れないことを確認
- [ ] プロンプト生成後も文字が適切に左揃えで表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)