### PR TITLE
fix: プロンプト出力ボックスのテキスト配置を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
 
             <section class="preview-section">
                 <h2 class="text-xl font-semibold text-gray-700 mb-6">2. 生成されたプロンプト</h2>
-                <div id="promptOutput" class="prompt-output">
+                <div id="promptOutput" class="prompt-output text-left block">
                     ここにプロンプトが表示されます...
                 </div>
                 <div class="mt-6 text-right">

--- a/style.css
+++ b/style.css
@@ -23,6 +23,7 @@ body {
     
     .form-section, .preview-section {
         margin-bottom: 16px;
+        text-align: left;
     }
     
     /* Mobile header adjustments */
@@ -39,6 +40,7 @@ body {
     padding: 24px;
     border-radius: 8px;
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    text-align: left;
 }
 
 /* Mobile form section styling */
@@ -262,10 +264,14 @@ button {
     overflow-x: auto; /* Horizontal scroll for long lines */
     text-align: left !important; /* Force left alignment */
     /* Use flex to ensure content starts at top-left */
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: flex-start;
+    display: block;
+    
+    position: relative;
+    left: 0;
+    right: auto;
+    float: none;
+    clear: both;
+    margin: 0;
 }
 
 /* Mobile prompt output styling */

--- a/style.css
+++ b/style.css
@@ -262,16 +262,24 @@ button {
     font-size: 0.9em;
     line-height: 1.6;
     overflow-x: auto; /* Horizontal scroll for long lines */
-    text-align: left !important; /* Force left alignment */
-    /* Use flex to ensure content starts at top-left */
-    display: block;
+    /* Tailwindのスタイルを上書き */
+    /* Tailwindのリセットを完全に上書き */
+    all: revert;  /* 一旦全てのスタイルをリセット */
     
-    position: relative;
-    left: 0;
-    right: auto;
-    float: none;
-    clear: both;
-    margin: 0;
+    /* 必要なスタイルを再定義 */
+    text-align: left !important;
+    display: block !important;
+    box-sizing: border-box;
+    width: 100%;
+    
+    /* 上記で消えたスタイルを再適用 */
+    background-color: #f9fafb;
+    border: 1px solid #e5e7eb;
+    padding: 16px;
+    border-radius: 6px;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+    font-size: 0.9em;
+    line-height: 1.6;
 }
 
 /* Mobile prompt output styling */

--- a/style.css
+++ b/style.css
@@ -260,6 +260,12 @@ button {
     font-size: 0.9em;
     line-height: 1.6;
     overflow-x: auto; /* Horizontal scroll for long lines */
+    text-align: left !important; /* Force left alignment */
+    /* Use flex to ensure content starts at top-left */
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
 }
 
 /* Mobile prompt output styling */


### PR DESCRIPTION
## Summary
- プロンプト出力ボックスのテキストが正しく左揃えで表示されるように修正
- Tailwindのスタイルリセットを適用して、確実にテキスト配置を制御

## Changes
- `index.html`: プロンプト出力要素に`text-left`と`block`クラスを追加
- `style.css`: `all: revert`を使用してTailwindのスタイルをリセットし、必要なスタイルを再定義

## Test plan
- [ ] プロンプト生成後、テキストが左揃えで表示されることを確認
- [ ] モバイル表示でもテキスト配置が正しいことを確認
- [ ] 既存の機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)