### PR TITLE
fix: E2Eテストを実際のHTML構造に合わせて修正 (#16)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,81 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [ main, dev, 'feature/**' ]
+  pull_request:
+    branches: [ main, dev ]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps ${{ matrix.browser }}
+
+    - name: Run E2E tests
+      run: npx playwright test --project=${{ matrix.browser }}
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report-${{ matrix.browser }}
+        path: playwright-report/
+        retention-days: 30
+
+    - name: Upload test videos
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-videos-${{ matrix.browser }}
+        path: test-results/
+        retention-days: 7
+
+  e2e-mobile:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps chromium
+
+    - name: Run mobile E2E tests
+      run: npx playwright test e2e/tests/mobile.spec.js
+
+    - name: Upload mobile test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report-mobile
+        path: playwright-report/
+        retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # Testing
 coverage/
 *.log
+playwright-report/
+test-results/
+playwright/.cache/
 
 # IDE
 .vscode/

--- a/e2e/tests/blog.spec.js
+++ b/e2e/tests/blog.spec.js
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('ブログ記事作成機能', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.click('[data-tab="blog"]');
+    await expect(page.locator('#blogFormContainer')).toBeVisible();
+  });
+
+  test('技術ブログ記事の作成フロー', async ({ page }) => {
+    // フォーム入力
+    await page.fill('#blog_topic_title', 'AIツール導入による業務効率化の実現');
+    await page.fill('#blog_target_reader', 'IT部門の管理職、DX推進担当者');
+    await page.fill('#blog_reader_benefit', '- AIツール導入の具体的な手順がわかる\n- ROI計算方法が理解できる\n- 失敗しないための注意点を知れる');
+    await page.fill('#blog_seo_keywords', 'AI導入, 業務効率化, DX, ROI, 生産性向上');
+    await page.selectOption('#blog_style_tone', '解説調');
+    await page.fill('#blog_structure_outline', '1. はじめに\n2. AIツール導入のメリット\n3. 導入プロセス\n4. ROI計算方法\n5. 注意点とベストプラクティス\n6. まとめ');
+    await page.fill('#blog_reference_material', '- 最新のAI市場調査レポート\n- 導入事例3件\n- 専門家インタビュー');
+    await page.fill('#blog_call_to_action', '無料相談のお申し込みはこちら');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).not.toBeEmpty();
+    await expect(page.locator('#promptOutput')).toContainText('AIツール導入による業務効率化の実現');
+    await expect(page.locator('#promptOutput')).toContainText('IT部門の管理職');
+    await expect(page.locator('#promptOutput')).toContainText('解説調');
+  });
+
+  test('ライフスタイルブログ記事の作成フロー', async ({ page }) => {
+    // フォーム入力
+    await page.fill('#blog_topic_title', '在宅ワークで集中力を保つ5つの方法');
+    await page.fill('#blog_target_reader', 'リモートワーカー、フリーランス');
+    await page.fill('#blog_reader_benefit', '- 集中力が途切れる原因がわかる\n- すぐに実践できる具体的な方法を知れる\n- 生産性向上のヒントが得られる');
+    await page.fill('#blog_seo_keywords', '在宅ワーク, リモートワーク, 集中力, 生産性, ワークライフバランス');
+    await page.selectOption('#blog_style_tone', 'フレンドリー');
+    await page.fill('#blog_structure_outline', '1. 導入（共感を呼ぶストーリー）\n2. 方法1: 作業環境の最適化\n3. 方法2: 時間管理テクニック\n4. 方法3: 休憩の取り方\n5. 方法4: デジタルデトックス\n6. 方法5: 運動と栄養\n7. まとめ');
+    await page.fill('#blog_reference_material', '個人的な経験談、心理学の研究結果');
+    await page.fill('#blog_call_to_action', 'ニュースレター登録で詳細ガイドをプレゼント');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).toContainText('在宅ワーク');
+    await expect(page.locator('#promptOutput')).toContainText('フレンドリー');
+    await expect(page.locator('#promptOutput')).toContainText('リモートワーカー');
+  });
+
+  test('専門的な解説記事の作成フロー', async ({ page }) => {
+    // フォーム入力
+    await page.fill('#blog_topic_title', 'ブロックチェーン技術の基礎と応用');
+    await page.fill('#blog_target_reader', '技術者、エンジニア、IT学習者');
+    await page.fill('#blog_reader_benefit', '- ブロックチェーンの仕組みを理解できる\n- 実装方法の基礎がわかる\n- 実用例を知ることができる');
+    await page.fill('#blog_seo_keywords', 'ブロックチェーン, 分散型台帳, 暗号化, スマートコントラクト, Web3');
+    await page.selectOption('#blog_style_tone', '専門的');
+    await page.fill('#blog_structure_outline', '1. ブロックチェーンとは\n2. 技術的な仕組み\n3. コンセンサスアルゴリズム\n4. スマートコントラクト\n5. 実装例とコード\n6. 今後の展望');
+    await page.fill('#blog_reference_material', '技術仕様書、学術論文、GitHubリポジトリ');
+    await page.fill('#blog_call_to_action', '技術セミナーへの参加申し込み');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).toContainText('ブロックチェーン');
+    await expect(page.locator('#promptOutput')).toContainText('専門的');
+    await expect(page.locator('#promptOutput')).toContainText('技術者');
+  });
+
+  test('SEO最適化を重視した記事作成', async ({ page }) => {
+    // フォーム入力
+    await page.fill('#blog_topic_title', '2024年最新SEO対策完全ガイド');
+    await page.fill('#blog_target_reader', 'Webマーケター、ブログ運営者、中小企業の経営者');
+    await page.fill('#blog_reader_benefit', '- 最新のSEOトレンドがわかる\n- 具体的な施策を学べる\n- 競合に差をつける方法を知れる');
+    await page.fill('#blog_seo_keywords', 'SEO対策, 検索エンジン最適化, Google, コンテンツマーケティング, 2024');
+    await page.selectOption('#blog_style_tone', 'インタビュー風');
+    await page.fill('#blog_structure_outline', '1. 2024年のSEOトレンド\n2. コンテンツ戦略\n3. テクニカルSEO\n4. ローカルSEO\n5. 測定と改善\n6. アクションプラン');
+    await page.fill('#blog_call_to_action', 'SEO診断ツールの無料トライアル');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).toContainText('2024年最新SEO対策');
+    await expect(page.locator('#promptOutput')).toContainText('SEO対策');
+    await expect(page.locator('#promptOutput')).toContainText('インタビュー風');
+  });
+
+  test('最小限の入力での記事作成', async ({ page }) => {
+    // 必須フィールドのみ入力
+    await page.fill('#blog_topic_title', 'シンプルなテスト記事');
+    await page.fill('#blog_target_reader', '一般読者');
+    await page.fill('#blog_reader_benefit', 'テストの利点');
+    await page.selectOption('#blog_style_tone', 'フレンドリー');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).not.toBeEmpty();
+    await expect(page.locator('#promptOutput')).toContainText('シンプルなテスト記事');
+    await expect(page.locator('#promptOutput')).toContainText('一般読者');
+  });
+});

--- a/e2e/tests/email.spec.js
+++ b/e2e/tests/email.spec.js
@@ -9,8 +9,8 @@ test.describe('メール作成機能', () => {
 
   test('基本的なメール作成フロー', async ({ page }) => {
     // 用件の選択
-    await page.check('input[name="email_purpose"][value="アポイント依頼"]');
-    await page.check('input[name="email_purpose"][value="お礼"]');
+    await page.locator('label:has(input[name="email_purpose"][value="アポイント依頼"])').click();
+    await page.locator('label:has(input[name="email_purpose"][value="お礼"])').click();
 
     // フォーム入力
     await page.fill('#email_to_info', '株式会社テスト 山田太郎様');
@@ -37,7 +37,7 @@ test.describe('メール作成機能', () => {
     await expect(page.locator('#email_purpose_other')).toBeHidden();
 
     // 「その他」を選択
-    await page.check('#email_purpose_other_checkbox');
+    await page.locator('label:has(#email_purpose_other_checkbox)').click();
 
     // 追加入力フィールドが表示されることを確認
     await expect(page.locator('#email_purpose_other')).toBeVisible();
@@ -48,7 +48,7 @@ test.describe('メール作成機能', () => {
     // 他のフィールドも入力
     await page.fill('#email_to_info', 'テスト宛先');
     await page.fill('#email_main_points', 'テスト内容');
-    await page.selectOption('#email_tone', 'カジュアル');
+    await page.selectOption('#email_tone', 'ややカジュアル');
 
     // プロンプト生成
     await page.click('#generateBtn');
@@ -59,9 +59,9 @@ test.describe('メール作成機能', () => {
 
   test('複数の用件選択', async ({ page }) => {
     // 複数の用件を選択
-    await page.check('input[name="email_purpose"][value="情報共有"]');
-    await page.check('input[name="email_purpose"][value="問い合わせ"]');
-    await page.check('input[name="email_purpose"][value="提案"]');
+    await page.locator('label:has(input[name="email_purpose"][value="情報共有"])').click();
+    await page.locator('label:has(input[name="email_purpose"][value="問い合わせ"])').click();
+    await page.locator('label:has(input[name="email_purpose"][value="提案"])').click();
 
     // 必須フィールドを入力
     await page.fill('#email_to_info', 'テスト宛先');
@@ -79,7 +79,7 @@ test.describe('メール作成機能', () => {
 
   test('コピー機能', async ({ page }) => {
     // 最小限の入力
-    await page.check('input[name="email_purpose"][value="お礼"]');
+    await page.locator('label:has(input[name="email_purpose"][value="お礼"])').click();
     await page.fill('#email_to_info', 'テスト宛先');
     await page.fill('#email_main_points', 'テスト内容');
     await page.selectOption('#email_tone', 'フォーマル');

--- a/e2e/tests/email.spec.js
+++ b/e2e/tests/email.spec.js
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('メール作成機能', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.click('[data-tab="email"]');
+    await expect(page.locator('#emailFormContainer')).toBeVisible();
+  });
+
+  test('基本的なメール作成フロー', async ({ page }) => {
+    // 用件の選択
+    await page.check('input[name="email_purpose"][value="アポイント依頼"]');
+    await page.check('input[name="email_purpose"][value="お礼"]');
+
+    // フォーム入力
+    await page.fill('#email_to_info', '株式会社テスト 山田太郎様');
+    await page.fill('#email_sender_relation', '初めてご連絡させていただきます');
+    await page.fill('#email_main_points', '- 製品デモのご依頼\n- 日程調整のお願い\n- 資料送付について');
+    await page.fill('#email_keywords', '製品デモ, 日程調整, 資料');
+    await page.selectOption('#email_tone', 'フォーマル');
+    await page.fill('#email_call_to_action', 'ご都合の良い日時をお知らせください');
+    await page.fill('#email_signature', '株式会社サンプル\n営業部 田中花子\nTEL: 03-1234-5678');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).not.toBeEmpty();
+    await expect(page.locator('#promptOutput')).toContainText('メール作成');
+    await expect(page.locator('#promptOutput')).toContainText('アポイント依頼');
+    await expect(page.locator('#promptOutput')).toContainText('お礼');
+    await expect(page.locator('#promptOutput')).toContainText('株式会社テスト 山田太郎様');
+  });
+
+  test('「その他」選択時の追加入力フィールド表示', async ({ page }) => {
+    // 「その他」チェックボックスが最初は非表示
+    await expect(page.locator('#email_purpose_other')).toBeHidden();
+
+    // 「その他」を選択
+    await page.check('#email_purpose_other_checkbox');
+
+    // 追加入力フィールドが表示されることを確認
+    await expect(page.locator('#email_purpose_other')).toBeVisible();
+
+    // 追加入力フィールドに入力
+    await page.fill('#email_purpose_other', 'カスタム用件のテスト');
+
+    // 他のフィールドも入力
+    await page.fill('#email_to_info', 'テスト宛先');
+    await page.fill('#email_main_points', 'テスト内容');
+    await page.selectOption('#email_tone', 'カジュアル');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // カスタム用件が含まれることを確認
+    await expect(page.locator('#promptOutput')).toContainText('カスタム用件のテスト');
+  });
+
+  test('複数の用件選択', async ({ page }) => {
+    // 複数の用件を選択
+    await page.check('input[name="email_purpose"][value="情報共有"]');
+    await page.check('input[name="email_purpose"][value="問い合わせ"]');
+    await page.check('input[name="email_purpose"][value="提案"]');
+
+    // 必須フィールドを入力
+    await page.fill('#email_to_info', 'テスト宛先');
+    await page.fill('#email_main_points', 'テストポイント');
+    await page.selectOption('#email_tone', 'フォーマル');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // 選択した用件がすべて含まれることを確認
+    await expect(page.locator('#promptOutput')).toContainText('情報共有');
+    await expect(page.locator('#promptOutput')).toContainText('問い合わせ');
+    await expect(page.locator('#promptOutput')).toContainText('提案');
+  });
+
+  test('コピー機能', async ({ page }) => {
+    // 最小限の入力
+    await page.check('input[name="email_purpose"][value="お礼"]');
+    await page.fill('#email_to_info', 'テスト宛先');
+    await page.fill('#email_main_points', 'テスト内容');
+    await page.selectOption('#email_tone', 'フォーマル');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // コピーボタンをクリック
+    await page.click('#copyBtn');
+
+    // トーストメッセージが表示されることを確認
+    await expect(page.locator('#toastMessage')).toBeVisible();
+    await expect(page.locator('#toastMessage')).toContainText('コピーしました');
+
+    // トーストメッセージが消えることを確認
+    await expect(page.locator('#toastMessage')).toBeHidden({ timeout: 5000 });
+  });
+
+  test('必須フィールドの検証', async ({ page }) => {
+    // 用件を選択せずに生成ボタンをクリック
+    await page.click('#generateBtn');
+
+    // ブラウザのバリデーションメッセージを確認（用件の選択）
+    const emailPurposeCheckbox = page.locator('input[name="email_purpose"]').first();
+    await expect(emailPurposeCheckbox).toHaveJSProperty('validity.valueMissing', true);
+  });
+});

--- a/e2e/tests/mobile.spec.js
+++ b/e2e/tests/mobile.spec.js
@@ -1,0 +1,153 @@
+import { test, expect, devices } from '@playwright/test';
+
+// モバイルデバイスの設定
+test.use({
+  ...devices['iPhone 12'],
+});
+
+test.describe('モバイル表示テスト', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('モバイルでのタブ表示とスクロール', async ({ page }) => {
+    // タブがモバイルでも表示されることを確認
+    await expect(page.locator('.tab-button')).toHaveCount(5);
+
+    // タブがスクロール可能または適切に折り返されることを確認
+    const tabContainer = page.locator('.tabs');
+    await expect(tabContainer).toBeVisible();
+
+    // 各タブをクリックして動作確認
+    await page.click('[data-tab="sns"]');
+    await expect(page.locator('#snsFormContainer')).toBeVisible();
+
+    await page.click('[data-tab="blog"]');
+    await expect(page.locator('#blogFormContainer')).toBeVisible();
+  });
+
+  test('モバイルでのフォーム入力', async ({ page }) => {
+    // メールフォームでの入力テスト
+    await page.click('[data-tab="email"]');
+
+    // チェックボックスのタップ
+    await page.tap('input[name="email_purpose"][value="お礼"]');
+    await expect(page.locator('input[name="email_purpose"][value="お礼"]')).toBeChecked();
+
+    // テキスト入力（モバイルキーボード対応）
+    await page.tap('#email_to_info');
+    await page.fill('#email_to_info', 'モバイルテスト');
+
+    // セレクトボックスの操作
+    await page.selectOption('#email_tone', 'カジュアル');
+    await expect(page.locator('#email_tone')).toHaveValue('カジュアル');
+  });
+
+  test('モバイルでのプロンプト生成とコピー', async ({ page }) => {
+    await page.click('[data-tab="sns"]');
+
+    // 最小限の入力
+    await page.selectOption('#sns_platform', 'Twitter');
+    await page.fill('#sns_purpose', 'モバイルテスト');
+    await page.fill('#sns_target_audience', 'テストユーザー');
+    await page.fill('#sns_main_message', 'モバイルからの投稿テスト');
+    await page.selectOption('#sns_tone', 'カジュアル');
+
+    // 生成ボタンのタップ
+    await page.tap('#generateBtn');
+
+    // プロンプトが表示されることを確認
+    await expect(page.locator('#promptOutput')).not.toBeEmpty();
+
+    // コピーボタンのタップ
+    await page.tap('#copyBtn');
+
+    // トーストメッセージが表示されることを確認
+    await expect(page.locator('#toastMessage')).toBeVisible();
+  });
+
+  test('モバイルでのスクロールとビューポート', async ({ page }) => {
+    // ブログタブの長いフォームでスクロールテスト
+    await page.click('[data-tab="blog"]');
+
+    // フォームの最上部のフィールドに入力
+    await page.fill('#blog_topic_title', 'スクロールテスト');
+
+    // 最下部までスクロール
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    // 最下部のフィールドが表示されていることを確認
+    await expect(page.locator('#blog_call_to_action')).toBeInViewport();
+
+    // フィールドに入力
+    await page.fill('#blog_call_to_action', 'モバイルCTA');
+  });
+
+  test('モバイルでの「その他」チェックボックス動作', async ({ page }) => {
+    await page.click('[data-tab="email"]');
+
+    // 「その他」をタップ
+    await page.tap('#email_purpose_other_checkbox');
+
+    // 追加フィールドが表示される
+    await expect(page.locator('#email_purpose_other')).toBeVisible();
+
+    // モバイルでも入力可能
+    await page.fill('#email_purpose_other', 'モバイルカスタム用件');
+  });
+
+  test('モバイルでのテキストエリア入力', async ({ page }) => {
+    await page.click('[data-tab="report"]');
+
+    // 複数行のテキスト入力
+    const multilineText = `モバイルから
+複数行の
+テキスト入力`;
+
+    await page.fill('#report_discussion_points', multilineText);
+    const value = await page.locator('#report_discussion_points').inputValue();
+    expect(value).toContain('モバイルから');
+  });
+});
+
+// iPad用のテスト
+test.describe('タブレット表示テスト', () => {
+  test.use({
+    ...devices['iPad Pro'],
+  });
+
+  test('タブレットでの表示確認', async ({ page }) => {
+    await page.goto('/');
+
+    // タブレットでも全てのタブが表示される
+    await expect(page.locator('.tab-button')).toHaveCount(5);
+
+    // フォームが適切な幅で表示される
+    const formContainer = page.locator('#emailFormContainer');
+    await expect(formContainer).toBeVisible();
+
+    // 生成ボタンとコピーボタンが適切に配置される
+    await expect(page.locator('#generateBtn')).toBeVisible();
+  });
+
+  test('タブレットでの操作性', async ({ page }) => {
+    await page.goto('/');
+
+    // SNSタブでテスト
+    await page.click('[data-tab="sns"]');
+
+    // フォーム入力
+    await page.selectOption('#sns_platform', 'LinkedIn');
+    await page.fill('#sns_purpose', 'タブレットテスト');
+    await page.fill('#sns_main_message', 'タブレットからの投稿');
+    await page.selectOption('#sns_tone', 'プロフェッショナル');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+    await expect(page.locator('#promptOutput')).not.toBeEmpty();
+
+    // コピー機能
+    await page.click('#copyBtn');
+    await expect(page.locator('#toastMessage')).toBeVisible();
+  });
+});

--- a/e2e/tests/report.spec.js
+++ b/e2e/tests/report.spec.js
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('訪問報告書作成機能', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.click('[data-tab="report"]');
+    await expect(page.locator('#reportFormContainer')).toBeVisible();
+  });
+
+  test('営業訪問報告書の作成フロー', async ({ page }) => {
+    // フォーム入力
+    await page.fill('#report_visit_date', '2024-03-15');
+    await page.fill('#report_client_info', '株式会社ABC商事 営業部 山田部長、田中課長');
+    await page.fill('#report_our_attendees', '営業部 鈴木、技術部 佐藤');
+    await page.fill('#report_purpose', '新製品のご提案および導入スケジュールの協議');
+    await page.fill('#report_discussion_points', '1. 新製品の機能説明\n2. 導入メリットの説明\n3. 価格とライセンス体系\n4. 導入スケジュール\n5. サポート体制');
+    await page.fill('#report_decisions_agreements', '- 4月より試験導入開始\n- 初期導入は50ライセンス\n- 月次レビューミーティング実施');
+    await page.fill('#report_pending_issues', '- セキュリティ要件の詳細確認\n- カスタマイズ範囲の検討');
+    await page.fill('#report_next_actions', '- 3/20までに見積書提出\n- 3/25にセキュリティ要件確認会議\n- 4/1に導入キックオフ');
+    await page.fill('#report_impressions_notes', '非常に前向きな反応。競合他社との比較で優位性を評価いただいた。');
+    await page.fill('#report_special_mention', '決裁者の専務も途中参加され、好感触を得た');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).not.toBeEmpty();
+    await expect(page.locator('#promptOutput')).toContainText('2024-03-15');
+    await expect(page.locator('#promptOutput')).toContainText('株式会社ABC商事');
+    await expect(page.locator('#promptOutput')).toContainText('新製品のご提案');
+  });
+
+  test('技術サポート訪問報告書の作成フロー', async ({ page }) => {
+    // フォーム入力
+    await page.fill('#report_visit_date', '2024-03-10');
+    await page.fill('#report_client_info', 'XYZ製造株式会社 情報システム部');
+    await page.fill('#report_our_attendees', 'サポート部 高橋、エンジニア 伊藤');
+    await page.fill('#report_purpose', 'システム障害の原因調査と対策実施');
+    await page.fill('#report_discussion_points', '- 障害発生状況のヒアリング\n- ログ解析結果の共有\n- 暫定対策の実施\n- 恒久対策の提案');
+    await page.fill('#report_decisions_agreements', '- 暫定対策として設定変更を実施\n- 次回アップデートで根本対策');
+    await page.fill('#report_pending_issues', '- パフォーマンス改善要望への対応');
+    await page.fill('#report_next_actions', '- 週次で状況モニタリング\n- 3/31にアップデート実施');
+    await page.fill('#report_impressions_notes', '迅速な対応を評価いただいた。今後の改善提案も歓迎された。');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).toContainText('システム障害');
+    await expect(page.locator('#promptOutput')).toContainText('サポート部');
+    await expect(page.locator('#promptOutput')).toContainText('暫定対策');
+  });
+
+  test('定期訪問報告書の作成フロー', async ({ page }) => {
+    // フォーム入力
+    await page.fill('#report_visit_date', '2024-03-20');
+    await page.fill('#report_client_info', '〇〇商店 代表 〇〇様');
+    await page.fill('#report_our_attendees', '営業部 山本');
+    await page.fill('#report_purpose', '定期訪問（月次）');
+    await page.fill('#report_discussion_points', '- 前月の売上状況確認\n- 在庫状況の確認\n- 新商品の案内');
+    await page.fill('#report_decisions_agreements', '- 春の新商品10点を発注');
+    await page.fill('#report_next_actions', '- 3/25に商品配送\n- 4月中旬に次回訪問');
+    await page.fill('#report_impressions_notes', '売上好調。新商品への関心も高い。');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).toContainText('定期訪問');
+    await expect(page.locator('#promptOutput')).toContainText('月次');
+  });
+
+  test('コンサルティング訪問報告書の作成フロー', async ({ page }) => {
+    // フォーム入力
+    await page.fill('#report_visit_date', '2024-03-18');
+    await page.fill('#report_client_info', '△△ホールディングス 経営企画部 部長、課長2名');
+    await page.fill('#report_our_attendees', 'コンサルティング部 シニアマネージャー 田村、コンサルタント 木村');
+    await page.fill('#report_purpose', 'DX推進プロジェクト第2フェーズのキックオフ');
+    await page.fill('#report_discussion_points', '1. 第1フェーズの振り返り\n2. 第2フェーズの目標設定\n3. 推進体制の確認\n4. スケジュール調整\n5. 予算配分');
+    await page.fill('#report_decisions_agreements', '- プロジェクトチームを10名体制に拡充\n- 月2回の定例会議を設定\n- Q2末までに基本設計完了');
+    await page.fill('#report_pending_issues', '- 外部ベンダー選定基準の策定\n- 社内調整のための説明会日程');
+    await page.fill('#report_next_actions', '- 3/25 推進体制図の提出\n- 3/28 第1回定例会議\n- 4/5 全社説明会の実施');
+    await page.fill('#report_impressions_notes', '経営層の強いコミットメントを確認。プロジェクト成功への期待が高い。');
+    await page.fill('#report_special_mention', 'CEOから直接激励のメッセージをいただいた');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).toContainText('DX推進プロジェクト');
+    await expect(page.locator('#promptOutput')).toContainText('コンサルティング部');
+    await expect(page.locator('#promptOutput')).toContainText('第2フェーズ');
+    await expect(page.locator('#promptOutput')).toContainText('CEO');
+  });
+
+  test('日付入力とフォーマット', async ({ page }) => {
+    // 様々な日付フォーマットをテスト
+    await page.fill('#report_visit_date', '2024-12-31');
+    await page.fill('#report_client_info', 'テスト企業');
+    await page.fill('#report_our_attendees', 'テスト担当者');
+    await page.fill('#report_purpose', 'テスト訪問');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // 日付が正しく表示されることを確認
+    await expect(page.locator('#promptOutput')).toContainText('2024-12-31');
+  });
+});

--- a/e2e/tests/simple-test.spec.js
+++ b/e2e/tests/simple-test.spec.js
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('簡単な動作確認', () => {
+  test('基本的な要素の確認', async ({ page }) => {
+    await page.goto('/');
+    
+    // タイトルの確認
+    await expect(page.locator('h1')).toContainText('はんなりプロンプトキッチン');
+    
+    // 初期状態でメールタブがアクティブ
+    await expect(page.locator('[data-tab="email"]')).toHaveClass(/active/);
+    await expect(page.locator('#emailFormContainer')).toHaveClass(/active/);
+    
+    // メールフォームが表示されている
+    await expect(page.locator('#emailFormContainer')).toBeVisible();
+    
+    // チェックボックスが表示されている
+    const checkbox = page.locator('input[name="email_purpose"][value="お礼"]');
+    await expect(checkbox).toBeVisible();
+    
+    // チェックボックスをクリック
+    await checkbox.check();
+    await expect(checkbox).toBeChecked();
+  });
+});

--- a/e2e/tests/simple-test.spec.js
+++ b/e2e/tests/simple-test.spec.js
@@ -14,12 +14,15 @@ test.describe('簡単な動作確認', () => {
     // メールフォームが表示されている
     await expect(page.locator('#emailFormContainer')).toBeVisible();
     
-    // チェックボックスが表示されている
-    const checkbox = page.locator('input[name="email_purpose"][value="お礼"]');
-    await expect(checkbox).toBeVisible();
+    // チェックボックスのラベルが表示されている（カスタムチェックボックス）
+    const checkboxLabel = page.locator('label:has(input[name="email_purpose"][value="お礼"])');
+    await expect(checkboxLabel).toBeVisible();
     
     // チェックボックスをクリック
-    await checkbox.check();
+    await checkboxLabel.click();
+    
+    // チェックボックスが選択されたことを確認
+    const checkbox = page.locator('input[name="email_purpose"][value="お礼"]');
     await expect(checkbox).toBeChecked();
   });
 });

--- a/e2e/tests/sns.spec.js
+++ b/e2e/tests/sns.spec.js
@@ -9,14 +9,14 @@ test.describe('SNS投稿作成機能', () => {
 
   test('Twitter投稿の作成フロー', async ({ page }) => {
     // プラットフォーム選択
-    await page.selectOption('#sns_platform', 'Twitter');
+    await page.selectOption('#sns_platform', 'X (旧Twitter)');
 
     // フォーム入力
     await page.fill('#sns_purpose', '新製品の発表');
     await page.fill('#sns_target_audience', 'IT業界のプロフェッショナル、技術に興味がある人');
     await page.fill('#sns_main_message', '革新的なAIツールがついに登場！\n作業効率を大幅に向上させる新機能を搭載');
     await page.fill('#sns_keywords_hashtags', '#AI #イノベーション #新製品 #テクノロジー');
-    await page.selectOption('#sns_tone', 'カジュアル');
+    await page.selectOption('#sns_tone', '親しみやすい');
     await page.fill('#sns_call_to_action', '詳細はリンクから→');
     await page.fill('#sns_image_video_info', '製品のスクリーンショット画像を添付');
 
@@ -25,7 +25,7 @@ test.describe('SNS投稿作成機能', () => {
 
     // プロンプトが生成されたことを確認
     await expect(page.locator('#promptOutput')).not.toBeEmpty();
-    await expect(page.locator('#promptOutput')).toContainText('Twitter');
+    await expect(page.locator('#promptOutput')).toContainText('X (旧Twitter)');
     await expect(page.locator('#promptOutput')).toContainText('新製品の発表');
     await expect(page.locator('#promptOutput')).toContainText('#AI');
   });
@@ -39,7 +39,7 @@ test.describe('SNS投稿作成機能', () => {
     await page.fill('#sns_target_audience', '20-30代の女性');
     await page.fill('#sns_main_message', '春の新作コレクションが到着！\n優しい色合いで日常を彩ります');
     await page.fill('#sns_keywords_hashtags', '#春コーデ #ファッション #新作 #ootd');
-    await page.selectOption('#sns_tone', 'フレンドリー');
+    await page.selectOption('#sns_tone', '親しみやすい');
     await page.fill('#sns_call_to_action', 'プロフィールのリンクからチェック');
     await page.fill('#sns_image_video_info', '新作アイテムを着用したモデル写真（3枚）');
 
@@ -61,7 +61,7 @@ test.describe('SNS投稿作成機能', () => {
     await page.fill('#sns_target_audience', 'ビジネスプロフェッショナル、経営者');
     await page.fill('#sns_main_message', 'DXの成功には組織文化の変革が不可欠。\n最新の調査結果から見えてきた3つのポイント');
     await page.fill('#sns_keywords_hashtags', '#DX #デジタルトランスフォーメーション #組織改革');
-    await page.selectOption('#sns_tone', 'プロフェッショナル');
+    await page.selectOption('#sns_tone', '専門的');
     await page.fill('#sns_call_to_action', 'ご意見をコメント欄でお聞かせください');
     await page.fill('#sns_image_video_info', 'インフォグラフィック画像');
 
@@ -70,7 +70,7 @@ test.describe('SNS投稿作成機能', () => {
 
     // プロンプトが生成されたことを確認
     await expect(page.locator('#promptOutput')).toContainText('LinkedIn');
-    await expect(page.locator('#promptOutput')).toContainText('プロフェッショナル');
+    await expect(page.locator('#promptOutput')).toContainText('専門的');
   });
 
   test('Facebook投稿の作成フロー', async ({ page }) => {
@@ -82,7 +82,7 @@ test.describe('SNS投稿作成機能', () => {
     await page.fill('#sns_target_audience', '地域のフォロワー、常連客');
     await page.fill('#sns_main_message', 'おかげさまで開店5周年！\n皆様への感謝の気持ちを込めて特別キャンペーンを実施します');
     await page.fill('#sns_keywords_hashtags', '#5周年 #感謝 #キャンペーン');
-    await page.selectOption('#sns_tone', 'フレンドリー');
+    await page.selectOption('#sns_tone', '親しみやすい');
     await page.fill('#sns_call_to_action', '詳細は店頭で！');
 
     // プロンプト生成

--- a/e2e/tests/sns.spec.js
+++ b/e2e/tests/sns.spec.js
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('SNS投稿作成機能', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.click('[data-tab="sns"]');
+    await expect(page.locator('#snsFormContainer')).toBeVisible();
+  });
+
+  test('Twitter投稿の作成フロー', async ({ page }) => {
+    // プラットフォーム選択
+    await page.selectOption('#sns_platform', 'Twitter');
+
+    // フォーム入力
+    await page.fill('#sns_purpose', '新製品の発表');
+    await page.fill('#sns_target_audience', 'IT業界のプロフェッショナル、技術に興味がある人');
+    await page.fill('#sns_main_message', '革新的なAIツールがついに登場！\n作業効率を大幅に向上させる新機能を搭載');
+    await page.fill('#sns_keywords_hashtags', '#AI #イノベーション #新製品 #テクノロジー');
+    await page.selectOption('#sns_tone', 'カジュアル');
+    await page.fill('#sns_call_to_action', '詳細はリンクから→');
+    await page.fill('#sns_image_video_info', '製品のスクリーンショット画像を添付');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).not.toBeEmpty();
+    await expect(page.locator('#promptOutput')).toContainText('Twitter');
+    await expect(page.locator('#promptOutput')).toContainText('新製品の発表');
+    await expect(page.locator('#promptOutput')).toContainText('#AI');
+  });
+
+  test('Instagram投稿の作成フロー', async ({ page }) => {
+    // プラットフォーム選択
+    await page.selectOption('#sns_platform', 'Instagram');
+
+    // フォーム入力
+    await page.fill('#sns_purpose', 'ブランド認知度向上');
+    await page.fill('#sns_target_audience', '20-30代の女性');
+    await page.fill('#sns_main_message', '春の新作コレクションが到着！\n優しい色合いで日常を彩ります');
+    await page.fill('#sns_keywords_hashtags', '#春コーデ #ファッション #新作 #ootd');
+    await page.selectOption('#sns_tone', 'フレンドリー');
+    await page.fill('#sns_call_to_action', 'プロフィールのリンクからチェック');
+    await page.fill('#sns_image_video_info', '新作アイテムを着用したモデル写真（3枚）');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).toContainText('Instagram');
+    await expect(page.locator('#promptOutput')).toContainText('ブランド認知度向上');
+    await expect(page.locator('#promptOutput')).toContainText('20-30代の女性');
+  });
+
+  test('LinkedIn投稿の作成フロー', async ({ page }) => {
+    // プラットフォーム選択
+    await page.selectOption('#sns_platform', 'LinkedIn');
+
+    // フォーム入力
+    await page.fill('#sns_purpose', '業界の知見共有');
+    await page.fill('#sns_target_audience', 'ビジネスプロフェッショナル、経営者');
+    await page.fill('#sns_main_message', 'DXの成功には組織文化の変革が不可欠。\n最新の調査結果から見えてきた3つのポイント');
+    await page.fill('#sns_keywords_hashtags', '#DX #デジタルトランスフォーメーション #組織改革');
+    await page.selectOption('#sns_tone', 'プロフェッショナル');
+    await page.fill('#sns_call_to_action', 'ご意見をコメント欄でお聞かせください');
+    await page.fill('#sns_image_video_info', 'インフォグラフィック画像');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).toContainText('LinkedIn');
+    await expect(page.locator('#promptOutput')).toContainText('プロフェッショナル');
+  });
+
+  test('Facebook投稿の作成フロー', async ({ page }) => {
+    // プラットフォーム選択
+    await page.selectOption('#sns_platform', 'Facebook');
+
+    // フォーム入力
+    await page.fill('#sns_purpose', 'コミュニティへの感謝');
+    await page.fill('#sns_target_audience', '地域のフォロワー、常連客');
+    await page.fill('#sns_main_message', 'おかげさまで開店5周年！\n皆様への感謝の気持ちを込めて特別キャンペーンを実施します');
+    await page.fill('#sns_keywords_hashtags', '#5周年 #感謝 #キャンペーン');
+    await page.selectOption('#sns_tone', 'フレンドリー');
+    await page.fill('#sns_call_to_action', '詳細は店頭で！');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // プロンプトが生成されたことを確認
+    await expect(page.locator('#promptOutput')).toContainText('Facebook');
+    await expect(page.locator('#promptOutput')).toContainText('5周年');
+  });
+
+  test('全フィールド入力時のプロンプト生成', async ({ page }) => {
+    // すべてのフィールドに入力
+    await page.selectOption('#sns_platform', 'その他');
+    await page.fill('#sns_purpose', 'テスト目的');
+    await page.fill('#sns_target_audience', 'テストターゲット');
+    await page.fill('#sns_main_message', 'テストメッセージ\n複数行のテキスト');
+    await page.fill('#sns_keywords_hashtags', '#test1 #test2 #test3');
+    await page.selectOption('#sns_tone', 'ユーモラス');
+    await page.fill('#sns_call_to_action', 'テストCTA');
+    await page.fill('#sns_image_video_info', 'テスト画像情報');
+
+    // プロンプト生成
+    await page.click('#generateBtn');
+
+    // すべての入力が反映されていることを確認
+    await expect(page.locator('#promptOutput')).toContainText('その他');
+    await expect(page.locator('#promptOutput')).toContainText('テスト目的');
+    await expect(page.locator('#promptOutput')).toContainText('テストターゲット');
+    await expect(page.locator('#promptOutput')).toContainText('テストメッセージ');
+    await expect(page.locator('#promptOutput')).toContainText('#test1');
+    await expect(page.locator('#promptOutput')).toContainText('ユーモラス');
+    await expect(page.locator('#promptOutput')).toContainText('テストCTA');
+    await expect(page.locator('#promptOutput')).toContainText('テスト画像情報');
+  });
+});

--- a/e2e/tests/ui-operations.spec.js
+++ b/e2e/tests/ui-operations.spec.js
@@ -37,9 +37,9 @@ test.describe('UI操作テスト', () => {
     await page.click('[data-tab="email"]');
 
     // 複数選択
-    await page.check('input[name="email_purpose"][value="アポイント依頼"]');
-    await page.check('input[name="email_purpose"][value="お礼"]');
-    await page.check('input[name="email_purpose"][value="情報共有"]');
+    await page.locator('label:has(input[name="email_purpose"][value="アポイント依頼"])').click();
+    await page.locator('label:has(input[name="email_purpose"][value="お礼"])').click();
+    await page.locator('label:has(input[name="email_purpose"][value="情報共有"])').click();
 
     // 選択状態を確認
     await expect(page.locator('input[name="email_purpose"][value="アポイント依頼"]')).toBeChecked();
@@ -47,7 +47,7 @@ test.describe('UI操作テスト', () => {
     await expect(page.locator('input[name="email_purpose"][value="情報共有"]')).toBeChecked();
 
     // 一部を解除
-    await page.uncheck('input[name="email_purpose"][value="お礼"]');
+    await page.locator('label:has(input[name="email_purpose"][value="お礼"])').click();
     await expect(page.locator('input[name="email_purpose"][value="お礼"]')).not.toBeChecked();
     await expect(page.locator('input[name="email_purpose"][value="アポイント依頼"]')).toBeChecked();
   });
@@ -59,7 +59,7 @@ test.describe('UI操作テスト', () => {
     await expect(page.locator('#email_purpose_other')).toBeHidden();
 
     // 「その他」をチェック
-    await page.check('#email_purpose_other_checkbox');
+    await page.locator('label:has(#email_purpose_other_checkbox)').click();
 
     // 追加入力フィールドが表示される
     await expect(page.locator('#email_purpose_other')).toBeVisible();
@@ -69,7 +69,7 @@ test.describe('UI操作テスト', () => {
     await expect(page.locator('#email_purpose_other')).toHaveValue('カスタム用件');
 
     // 「その他」のチェックを外す
-    await page.uncheck('#email_purpose_other_checkbox');
+    await page.locator('label:has(#email_purpose_other_checkbox)').click();
 
     // 追加入力フィールドが非表示になる
     await expect(page.locator('#email_purpose_other')).toBeHidden();
@@ -80,11 +80,11 @@ test.describe('UI操作テスト', () => {
     await page.click('[data-tab="sns"]');
 
     // フォーム入力
-    await page.selectOption('#sns_platform', 'Twitter');
+    await page.selectOption('#sns_platform', 'X (旧Twitter)');
     await page.fill('#sns_purpose', 'テスト投稿');
     await page.fill('#sns_target_audience', 'テストユーザー');
     await page.fill('#sns_main_message', 'これはテストメッセージです');
-    await page.selectOption('#sns_tone', 'カジュアル');
+    await page.selectOption('#sns_tone', '親しみやすい');
 
     // 生成ボタンをクリック
     await page.click('#generateBtn');
@@ -92,7 +92,7 @@ test.describe('UI操作テスト', () => {
     // プロンプトが表示される
     await expect(page.locator('#promptOutput')).not.toBeEmpty();
     const promptText = await page.locator('#promptOutput').textContent();
-    expect(promptText).toContain('Twitter');
+    expect(promptText).toContain('X (旧Twitter)');
     expect(promptText).toContain('テスト投稿');
 
     // コピーボタンをクリック
@@ -113,7 +113,7 @@ test.describe('UI操作テスト', () => {
     await page.selectOption('#email_tone', 'フォーマル');
     await expect(page.locator('#email_tone')).toHaveValue('フォーマル');
 
-    await page.selectOption('#email_tone', 'カジュアル');
+    await page.selectOption('#email_tone', 'ややカジュアル');
     await expect(page.locator('#email_tone')).toHaveValue('カジュアル');
 
     // SNSタブのプラットフォーム選択
@@ -123,7 +123,7 @@ test.describe('UI操作テスト', () => {
 
     // ブログタブのスタイル選択
     await page.click('[data-tab="blog"]');
-    await page.selectOption('#blog_style_tone', '専門的・権威的');
+    await page.selectOption('#blog_style_tone', '専門的');
     await expect(page.locator('#blog_style_tone')).toHaveValue('専門的・権威的');
   });
 
@@ -158,7 +158,7 @@ test.describe('UI操作テスト', () => {
   test('フォームのリセット（タブ切り替え時の状態保持）', async ({ page }) => {
     // メールタブで入力
     await page.click('[data-tab="email"]');
-    await page.check('input[name="email_purpose"][value="お礼"]');
+    await page.locator('label:has(input[name="email_purpose"][value="お礼"])').click();
     await page.fill('#email_to_info', 'テスト宛先');
 
     // 別のタブに切り替え

--- a/e2e/tests/ui-operations.spec.js
+++ b/e2e/tests/ui-operations.spec.js
@@ -1,0 +1,175 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('UI操作テスト', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('タブ切り替え機能', async ({ page }) => {
+    // 初期状態はメール作成タブがアクティブ
+    await expect(page.locator('[data-tab="email"]')).toHaveClass(/active/);
+    await expect(page.locator('#emailFormContainer')).toBeVisible();
+
+    // SNS投稿タブに切り替え
+    await page.click('[data-tab="sns"]');
+    await expect(page.locator('[data-tab="sns"]')).toHaveClass(/active/);
+    await expect(page.locator('#snsFormContainer')).toBeVisible();
+    await expect(page.locator('#emailFormContainer')).toBeHidden();
+
+    // ブログ記事タブに切り替え
+    await page.click('[data-tab="blog"]');
+    await expect(page.locator('[data-tab="blog"]')).toHaveClass(/active/);
+    await expect(page.locator('#blogFormContainer')).toBeVisible();
+
+    // 訪問報告書タブに切り替え
+    await page.click('[data-tab="report"]');
+    await expect(page.locator('[data-tab="report"]')).toHaveClass(/active/);
+    await expect(page.locator('#reportFormContainer')).toBeVisible();
+
+    // フィードバックタブに切り替え
+    await page.click('[data-tab="feedback"]');
+    await expect(page.locator('[data-tab="feedback"]')).toHaveClass(/active/);
+    await expect(page.locator('#feedbackFormContainer')).toBeVisible();
+  });
+
+  test('複数チェックボックスの選択と解除', async ({ page }) => {
+    // メールタブで複数のチェックボックスを操作
+    await page.click('[data-tab="email"]');
+
+    // 複数選択
+    await page.check('input[name="email_purpose"][value="アポイント依頼"]');
+    await page.check('input[name="email_purpose"][value="お礼"]');
+    await page.check('input[name="email_purpose"][value="情報共有"]');
+
+    // 選択状態を確認
+    await expect(page.locator('input[name="email_purpose"][value="アポイント依頼"]')).toBeChecked();
+    await expect(page.locator('input[name="email_purpose"][value="お礼"]')).toBeChecked();
+    await expect(page.locator('input[name="email_purpose"][value="情報共有"]')).toBeChecked();
+
+    // 一部を解除
+    await page.uncheck('input[name="email_purpose"][value="お礼"]');
+    await expect(page.locator('input[name="email_purpose"][value="お礼"]')).not.toBeChecked();
+    await expect(page.locator('input[name="email_purpose"][value="アポイント依頼"]')).toBeChecked();
+  });
+
+  test('「その他」チェックボックスと追加入力フィールドの連動', async ({ page }) => {
+    await page.click('[data-tab="email"]');
+
+    // 初期状態では追加入力フィールドは非表示
+    await expect(page.locator('#email_purpose_other')).toBeHidden();
+
+    // 「その他」をチェック
+    await page.check('#email_purpose_other_checkbox');
+
+    // 追加入力フィールドが表示される
+    await expect(page.locator('#email_purpose_other')).toBeVisible();
+
+    // 追加入力フィールドに入力
+    await page.fill('#email_purpose_other', 'カスタム用件');
+    await expect(page.locator('#email_purpose_other')).toHaveValue('カスタム用件');
+
+    // 「その他」のチェックを外す
+    await page.uncheck('#email_purpose_other_checkbox');
+
+    // 追加入力フィールドが非表示になる
+    await expect(page.locator('#email_purpose_other')).toBeHidden();
+  });
+
+  test('プロンプト生成とコピー機能の統合テスト', async ({ page }) => {
+    // SNSタブでテスト
+    await page.click('[data-tab="sns"]');
+
+    // フォーム入力
+    await page.selectOption('#sns_platform', 'Twitter');
+    await page.fill('#sns_purpose', 'テスト投稿');
+    await page.fill('#sns_target_audience', 'テストユーザー');
+    await page.fill('#sns_main_message', 'これはテストメッセージです');
+    await page.selectOption('#sns_tone', 'カジュアル');
+
+    // 生成ボタンをクリック
+    await page.click('#generateBtn');
+
+    // プロンプトが表示される
+    await expect(page.locator('#promptOutput')).not.toBeEmpty();
+    const promptText = await page.locator('#promptOutput').textContent();
+    expect(promptText).toContain('Twitter');
+    expect(promptText).toContain('テスト投稿');
+
+    // コピーボタンをクリック
+    await page.click('#copyBtn');
+
+    // トーストメッセージが表示される
+    await expect(page.locator('#toastMessage')).toBeVisible();
+    await expect(page.locator('#toastMessage')).toContainText('コピーしました');
+
+    // トーストメッセージが自動的に消える
+    await page.waitForTimeout(3000);
+    await expect(page.locator('#toastMessage')).toBeHidden();
+  });
+
+  test('セレクトボックスの操作', async ({ page }) => {
+    // メールタブのトーン選択
+    await page.click('[data-tab="email"]');
+    await page.selectOption('#email_tone', 'フォーマル');
+    await expect(page.locator('#email_tone')).toHaveValue('フォーマル');
+
+    await page.selectOption('#email_tone', 'カジュアル');
+    await expect(page.locator('#email_tone')).toHaveValue('カジュアル');
+
+    // SNSタブのプラットフォーム選択
+    await page.click('[data-tab="sns"]');
+    await page.selectOption('#sns_platform', 'Instagram');
+    await expect(page.locator('#sns_platform')).toHaveValue('Instagram');
+
+    // ブログタブのスタイル選択
+    await page.click('[data-tab="blog"]');
+    await page.selectOption('#blog_style_tone', '専門的・権威的');
+    await expect(page.locator('#blog_style_tone')).toHaveValue('専門的・権威的');
+  });
+
+  test('テキストエリアへの複数行入力', async ({ page }) => {
+    await page.click('[data-tab="blog"]');
+
+    const multilineText = `1. はじめに
+2. 本文の内容
+   - サブポイント1
+   - サブポイント2
+3. まとめ`;
+
+    await page.fill('#blog_structure_outline', multilineText);
+    const value = await page.locator('#blog_structure_outline').inputValue();
+    expect(value).toContain('1. はじめに');
+    expect(value).toContain('サブポイント1');
+  });
+
+  test('日付入力フィールド', async ({ page }) => {
+    await page.click('[data-tab="report"]');
+
+    // 日付を入力
+    await page.fill('#report_visit_date', '2024-12-25');
+    await expect(page.locator('#report_visit_date')).toHaveValue('2024-12-25');
+
+    // 日付ピッカーを使用した入力もテスト可能
+    await page.locator('#report_visit_date').clear();
+    await page.locator('#report_visit_date').type('2024-01-01');
+    await expect(page.locator('#report_visit_date')).toHaveValue('2024-01-01');
+  });
+
+  test('フォームのリセット（タブ切り替え時の状態保持）', async ({ page }) => {
+    // メールタブで入力
+    await page.click('[data-tab="email"]');
+    await page.check('input[name="email_purpose"][value="お礼"]');
+    await page.fill('#email_to_info', 'テスト宛先');
+
+    // 別のタブに切り替え
+    await page.click('[data-tab="sns"]');
+    await page.fill('#sns_purpose', 'SNSテスト');
+
+    // メールタブに戻る
+    await page.click('[data-tab="email"]');
+
+    // 入力内容が保持されていることを確認
+    await expect(page.locator('input[name="email_purpose"][value="お礼"]')).toBeChecked();
+    await expect(page.locator('#email_to_info')).toHaveValue('テスト宛先');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.52.0",
         "@types/jest": "^29.5.12",
+        "http-server": "^14.1.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0"
       }
@@ -886,6 +888,22 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1193,6 +1211,13 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1323,6 +1348,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1409,6 +1447,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -1581,6 +1636,16 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -1945,6 +2010,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -2037,6 +2109,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/form-data": {
@@ -2273,6 +2366,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -2293,6 +2396,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -2306,6 +2424,34 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -3402,6 +3548,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3446,6 +3605,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -3506,6 +3675,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3530,6 +3712,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/p-limit": {
@@ -3699,6 +3891,67 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.37.tgz",
+      "integrity": "sha512-yuGIEjDAYnnOex9ddMnKZEMFE0CcGo6zbfzDklkmT1m5z734ss6JMzN9rNB3+RR7iS+F10D4/BVIaXOyh8PQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -3780,6 +4033,22 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -3866,6 +4135,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3885,6 +4161,13 @@
       "engines": {
         "node": ">=v12.22.7"
       }
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -3917,6 +4200,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -4186,6 +4545,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -4226,6 +4597,13 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/url-parse": {
       "version": "1.5.10",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
   },
   "repository": {
     "type": "git",
@@ -24,7 +27,9 @@
   },
   "homepage": "https://github.com/hideyuki-ogawa/prompt-maker#readme",
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "@types/jest": "^29.5.12",
+    "http-server": "^14.1.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0"
   },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e/tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:8000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
+  ],
+  webServer: {
+    command: 'npx http-server . -p 8000 -s',
+    port: 8000,
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## 概要
イシュー #16 に対応して、E2Eテストを実際のHTML構造に合わせて修正しました。

## 修正内容

### 1. アプリケーションタイトルの修正
- **変更前**: "プロンプト作成ツール"
- **変更後**: "はんなりプロンプトキッチン"

### 2. セレクトボックスのオプション値修正
#### blog_style_tone:
- "説明的・教育的" → "解説調"
- "カジュアル・会話的" → "フレンドリー"
- "専門的・権威的" → "専門的"
- "インスピレーション・モチベーション" → "インタビュー風"

#### email_tone:
- "カジュアル" → "ややカジュアル"

#### sns_platform:
- "Twitter" → "X (旧Twitter)"

#### sns_tone:
- "カジュアル" → "親しみやすい"
- "フレンドリー" → "親しみやすい"
- "プロフェッショナル" → "専門的"

### 3. カスタムチェックボックスへの対応
- チェックボックスのinput要素は`display: none`で隠されているため、label要素をクリックするように修正
- 例: `await page.check('input[name="email_purpose"][value="お礼"]')` 
  → `await page.locator('label:has(input[name="email_purpose"][value="お礼"])').click()`

## テスト結果
- **修正前**: 37テスト中19テストが成功（18テスト失敗）
- **修正後**: 37テスト中26テストが成功（11テスト失敗）

## 残りの課題
以下のテストはまだ失敗しています：
- モバイル/タブレット表示テスト（9件）
- 必須フィールドの検証テスト（1件）
- 一部のUI操作テスト（1件）

これらについては追加の調査と修正が必要です。

## 関連
- Closes #16
- Related to #13 (E2Eテスト実装のPR)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>