### PR TITLE
fix: プロンプト表示の崩れを修正するためCSSを以前の状態に戻す (#20)

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
 
             <section class="preview-section">
                 <h2 class="text-xl font-semibold text-gray-700 mb-6">2. 生成されたプロンプト</h2>
-                <div id="promptOutput" class="prompt-output text-left block">
+                <div id="promptOutput" class="prompt-output">
                     ここにプロンプトが表示されます...
                 </div>
                 <div class="mt-6 text-right">

--- a/style.css
+++ b/style.css
@@ -262,24 +262,16 @@ button {
     font-size: 0.9em;
     line-height: 1.6;
     overflow-x: auto; /* Horizontal scroll for long lines */
-    /* Tailwindのスタイルを上書き */
-    /* Tailwindのリセットを完全に上書き */
-    all: revert;  /* 一旦全てのスタイルをリセット */
+    text-align: left !important; /* Force left alignment */
+    /* Use flex to ensure content starts at top-left */
+    display: block;
     
-    /* 必要なスタイルを再定義 */
-    text-align: left !important;
-    display: block !important;
-    box-sizing: border-box;
-    width: 100%;
-    
-    /* 上記で消えたスタイルを再適用 */
-    background-color: #f9fafb;
-    border: 1px solid #e5e7eb;
-    padding: 16px;
-    border-radius: 6px;
-    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
-    font-size: 0.9em;
-    line-height: 1.6;
+    position: relative;
+    left: 0;
+    right: auto;
+    float: none;
+    clear: both;
+    margin: 0;
 }
 
 /* Mobile prompt output styling */


### PR DESCRIPTION
## Summary
- プロンプト表示を左上から始めるための変更により、全体の表示が崩れる問題が発生
- 問題を解決するため、コミット 9e035fc の CSS 変更をリバート

## Test plan
- [ ] プロンプト生成機能が正常に動作することを確認
- [ ] 生成されたプロンプトの表示が崩れていないことを確認
- [ ] モバイル表示でも問題がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)