### PR TITLE
feat: プロンプト表示を右側から下側に移動し、ボタン配置を改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
+
+.claude

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
             <!-- タブボタンは動的に生成されます -->
         </div>
 
-        <div class="grid md:grid-cols-2 gap-8">
+        <div class="space-y-8">
             <section class="form-section">
                 <!-- フォームコンテナは動的に生成されます -->
                 <div class="pt-8">
@@ -29,12 +29,14 @@
 
             <section class="preview-section">
                 <h2 class="text-xl font-semibold text-gray-700 mb-6">2. 生成されたプロンプト</h2>
-                <div id="promptOutput" class="prompt-output">
-                    ここにプロンプトが表示されます...
-                </div>
-                <div class="mt-6 flex gap-3 justify-end">
-                    <button type="button" id="clearBtn" class="btn-secondary">クリア</button>
-                    <button type="button" id="copyBtn" class="btn-secondary">プロンプトをコピー</button>
+                <div class="relative">
+                    <div id="promptOutput" class="prompt-output">
+                        ここにプロンプトが表示されます...
+                    </div>
+                    <div class="absolute top-2 right-2 flex gap-2">
+                        <button type="button" id="clearBtn" class="btn-secondary text-xs px-2 py-1">クリア</button>
+                        <button type="button" id="copyBtn" class="btn-secondary text-xs px-2 py-1">コピー</button>
+                    </div>
                 </div>
             </section>
         </div>


### PR DESCRIPTION
- UIレイアウトを2カラムから縦並びに変更
- プロンプト表示エリアを下部に移動してより使いやすいUIに
- クリア・コピーボタンをプロンプトエリア右上に移動
- ボタンサイズを小さくしてコンパクトに調整

🤖 Generated with [Claude Code](https://claude.ai/code)